### PR TITLE
Edit extension promo text and Chrome Web Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![Demo](doc/demo.gif)
 
 ## Want `s/` extension?
-Get it from [Chrome Web Store](https://chrome.google.com/webstore/detail/short/hoobjcdfefnngjeepgjkiojpcicciihc) or build it from [source](https://github.com/byliuyang/short-ext)
+Get it from [Chrome Web Store](https://s.time4hacks.com/r/ext) or build it from [source](https://github.com/byliuyang/short-ext)
 
 ## Prerequisites
 - Node.js v12.7.0

--- a/app/adapter/web/src/component/promos/ExtPromo.scss
+++ b/app/adapter/web/src/component/promos/ExtPromo.scss
@@ -8,13 +8,10 @@
   color       : black;
 
   a {
-    font-weight      : $font-weight-bold;
+    font-weight      : $font-weight-semi-bold;
     padding          : 3px 10px;
     text-decoration  : none;
-    color            : white;
-    border-radius    : 2px;
-    background-color : #212121;
-
+    color            : black;
 
     &:hover {
       opacity : 0.9;

--- a/app/adapter/web/src/component/promos/ExtPromo.tsx
+++ b/app/adapter/web/src/component/promos/ExtPromo.tsx
@@ -8,15 +8,13 @@ export class ExtPromo extends Component {
     return (
       <Notice>
         <div className={'ext-promo'}>
-          Type less with&nbsp;
           <a
             target={'_blank'}
-            title={'Get s/'}
-            href={'https://s.time4hacks.com/r/shortext'}
+            title={'Get Chrome Extension'}
+            href={'https://s.time4hacks.com/r/ext'}
           >
-            s/
+            Get Chrome Extension
           </a>
-          &nbsp;.
         </div>
       </Notice>
     );


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Promo banner shows `Type less with s/ .`
### Screenshots
<img width="645" alt="Screen Shot 2019-08-25 at 9 34 13 AM" src="https://user-images.githubusercontent.com/3537801/63652949-86231000-c71b-11e9-968b-7b9dcd5733da.png">

## New Behavior
### Description
Promo banner shows `Get Chrome Extension`
### Screenshots
<img width="478" alt="Screen Shot 2019-08-25 at 9 36 43 AM" src="https://user-images.githubusercontent.com/3537801/63652996-e1550280-c71b-11e9-9f14-168a7e424d3f.png">
