### PR TITLE
Update title and add favicon to 404 page

### DIFF
--- a/app/adapter/web/public/404.html
+++ b/app/adapter/web/public/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Short | Page Not Found</title>
     <link rel="stylesheet" href="404.css">
 </head>
 <body>

--- a/app/adapter/web/public/404.html
+++ b/app/adapter/web/public/404.html
@@ -2,6 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="icon" type="image/png" href="icons/logo-16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="icons/logo-48.png" sizes="48x48">
+    <link rel="icon" type="image/png" href="icons/logo-128.png" sizes="128x128">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
     <title>Short | Page Not Found</title>
     <link rel="stylesheet" href="404.css">
 </head>


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
1. 404.html has default title
2. 404.html doesn't have favicon

### Screenshots
<img width="210" alt="Screen Shot 2019-08-31 at 7 44 49 PM" src="https://user-images.githubusercontent.com/3537801/64071126-d15f8600-cc27-11e9-9387-950404e1f1be.png">

## New Behavior
### Description
1. Update 404.html title to "Short | Page Not Found"
2. Add favicon to 404.html

### Screenshots
<img width="210" alt="Screen Shot 2019-08-31 at 7 47 24 PM" src="https://user-images.githubusercontent.com/3537801/64071137-2ef3d280-cc28-11e9-82f4-a50a389a16b1.png">
