### PR TITLE
Swap domain name to short-d.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Get `s/` Chrome extension
 
-Install it from [Chrome Web Store](https://s.time4hacks.com/r/ext) or build it
+Install it from [Chrome Web Store](https://short-d.com/r/ext) or build it
 from [source](https://github.com/byliuyang/short-ext)
 
 ## Getting Started
@@ -214,7 +214,7 @@ of this repository before making a change.
 
 ### Discussions
 
-Please join this [Slack channel](https://s.time4hacks.com/r/short-slack) to
+Please join this [Slack channel](https://short-d.com/r/short-slack) to
 discuss bugs, dev environment setup, tooling, and coding best practices.
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Get `s/` Chrome extension
 
 Install it from [Chrome Web Store](https://short-d.com/r/ext) or build it
-from [source](https://github.com/byliuyang/short-ext)
+from [source](https://short-d.com/r/ext-code)
 
 ## Getting Started
 
@@ -53,7 +53,7 @@ git clone https://github.com/byliuyang/short.git
 
 ### Create reCAPTCHA account
 
-1. Sign up at [ReCAPTCHA](http://www.google.com/recaptcha/admin) with the
+1. Sign up at [ReCAPTCHA](https://short-d.com/r/recaptcha) with the
    following configurations:
 
    | Field           | Value          |
@@ -69,7 +69,7 @@ git clone https://github.com/byliuyang/short.git
 ### Create Github OAuth Application
 
 1. Create a new OAuth app at
-   [Github Developers](https://github.com/settings/developers) with the
+   [Github Developers](https://short-d.com/r/ghdev) with the
    following configurations:
    
    | Field                      | Value                                            |
@@ -114,7 +114,7 @@ Visit [http://localhost:3000](http://localhost:3000)
 - Go v1.13.1
 - Node.js v12.12.0
 - Yarn v1.19.1
-- Postgresql v12.0 ( or use [ElephantSQL](https://www.elephantsql.com) instead )
+- Postgresql v12.0 ( or use [ElephantSQL](https://short-d.com/r/sql) instead )
 
 ### Backend
 
@@ -178,15 +178,15 @@ continuous deployment instead.
 
 ## Tools We Use
 
-- [Drone](https://ci.time4hacks.com/byliuyang/short/): Continuous integration
+- [Drone](https://short-d.com/r/ci): Continuous integration
   written in Go
-- [Sourcegraph](https://cs.time4hacks.com/github.com/byliuyang/short): Code
+- [Sourcegraph](https://short-d.com/r/cs): Code
   search written in Go
   ![Tooltip during code review](doc/sourcegraph/reference.png)
-- [Code Climate](https://codeclimate.com/github/byliuyang/short): Automated code
+- [Code Climate](https://short-d.com/r/cs): Automated code
   review
 - [ElephantSQL](https://www.elephantsql.com): Managed PostgreSQL service.
-- [QuickDBD](https://www.quickdatabasediagrams.com): Draw database diagrams by
+- [QuickDBD](https://short-d.com/r/db): Draw database diagrams by
   typing.
 
 ## Contributing
@@ -214,7 +214,7 @@ of this repository before making a change.
 
 ### Discussions
 
-Please join this [Slack channel](https://short-d.com/r/short-slack) to
+Please join this [Slack channel](https://short-d.com/r/slack) to
 discuss bugs, dev environment setup, tooling, and coding best practices.
 
 ## Author

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
-REACT_APP_GRAPHQL_API_BASE_URL=https://graphql-api-s.time4hacks.com
-REACT_APP_HTTP_API_BASE_URL=https://http-api-s.time4hacks.com
+REACT_APP_GRAPHQL_API_BASE_URL=https://gql.short-d.com
+REACT_APP_HTTP_API_BASE_URL=https://api.short-d.com


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Domain names are too long:
- Homepage => https://s.time4hacks.com
- HTTP API => https://http-api-s.time4hacks.com
- GraphQL API => https://graphql-api-s.time4hacks.com

## New Behavior
### Description
short-d.com is used as the new domain name:
- Homepage => https://short-d.com
- HTTP API => https://api.short-d.com
- GraphQL API => https://gql.short-d.com
