### PR TITLE
Change kgs port from http to https

### DIFF
--- a/k8s/backend-deployment.staging.yaml
+++ b/k8s/backend-deployment.staging.yaml
@@ -93,9 +93,9 @@ spec:
             - name: KEY_GEN_BUFFER_SIZE
               value: "10"
             - name: KEY_GEN_HOSTNAME
-              value: "kgs-1"
+              value: kgs1-staging.short-d.com
             - name: KEY_GEN_PORT
-              value: "80"
+              value: "443"
         - name: db
           image: postgres:12
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
`first record does not look like a TLS handshake` error is thrown when trying to fetch keys from key generation service. This implies `short backend` is not able to connect to `key generation service`. `kgs` is accessible through port `443` instead of port `80`.

## New Behavior
### Description
Short backend is able to connect to key generation service successfully.
