### PR TITLE
Replace userEmail with user for authentication logic

### DIFF
--- a/backend/app/adapter/graphql/resolver/mutation.go
+++ b/backend/app/adapter/graphql/resolver/mutation.go
@@ -63,7 +63,7 @@ func (m Mutation) CreateURL(args *CreateURLArgs) (*URL, error) {
 	}
 
 	authToken := args.AuthToken
-	userEmail, err := m.authenticator.GetUserEmail(authToken)
+	user, err := m.authenticator.GetUser(authToken)
 	if err != nil {
 		m.logger.Error(err)
 		return nil, ErrInvalidAuthToken(authToken)
@@ -73,7 +73,7 @@ func (m Mutation) CreateURL(args *CreateURLArgs) (*URL, error) {
 		trace1 := trace.Next("CreateURL")
 		defer trace1.End()
 
-		newURL, err := m.urlCreator.CreateURL(u, userEmail)
+		newURL, err := m.urlCreator.CreateURL(u, user.Email)
 		if err != nil {
 			m.logger.Error(err)
 			return nil, ErrUnknown{}
@@ -85,7 +85,7 @@ func (m Mutation) CreateURL(args *CreateURLArgs) (*URL, error) {
 	trace1 := trace.Next("CreateURLWithCustomAlias")
 	defer trace1.End()
 
-	newURL, err := m.urlCreator.CreateURLWithCustomAlias(u, *customAlias, userEmail)
+	newURL, err := m.urlCreator.CreateURLWithCustomAlias(u, *customAlias, user.Email)
 	if err == nil {
 		return &URL{url: newURL}, nil
 	}

--- a/backend/app/usecase/auth/authenticator.go
+++ b/backend/app/usecase/auth/authenticator.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"short/app/entity"
 	"time"
 
 	"github.com/byliuyang/app/fw"
@@ -45,25 +46,27 @@ func (a Authenticator) IsSignedIn(token string) bool {
 	return true
 }
 
-func (a Authenticator) GetUserEmail(token string) (string, error) {
+func (a Authenticator) GetUser(token string) (entity.User, error) {
 	payload, err := a.getPayload(token)
 	if err != nil {
-		return "", err
+		return entity.User{}, err
 	}
 
 	if !a.isTokenValid(payload, a.tokenValidDuration) {
-		return "", errors.New("token expired")
+		return entity.User{}, errors.New("token expired")
 	}
 
 	if len(payload.email) < 1 {
-		return "", errors.New("email can't be empty")
+		return entity.User{}, errors.New("email can't be empty")
 	}
-	return payload.email, nil
+	return entity.User{
+		Email: payload.email,
+	}, nil
 }
 
-func (a Authenticator) GenerateToken(email string) (string, error) {
+func (a Authenticator) GenerateToken(user entity.User) (string, error) {
 	issuedAt := a.timer.Now()
-	payload := newPayload(email, issuedAt)
+	payload := newPayload(user.Email, issuedAt)
 	tokenPayload := payload.TokenPayload()
 	return a.tokenizer.Encode(tokenPayload)
 }

--- a/backend/app/usecase/auth/authenticator.go
+++ b/backend/app/usecase/auth/authenticator.go
@@ -40,11 +40,7 @@ func (a Authenticator) IsSignedIn(token string) bool {
 		return false
 	}
 
-	if !a.isTokenValid(payload, a.tokenValidDuration) {
-		return false
-	}
-
-	return true
+	return a.isTokenValid(payload, a.tokenValidDuration)
 }
 
 // GetUser decodes authentication token to user data

--- a/backend/app/usecase/auth/authenticator.go
+++ b/backend/app/usecase/auth/authenticator.go
@@ -33,6 +33,7 @@ func (a Authenticator) getPayload(token string) (Payload, error) {
 	return payload, nil
 }
 
+// IsSignedIn checks whether user successfully signed in
 func (a Authenticator) IsSignedIn(token string) bool {
 	payload, err := a.getPayload(token)
 	if err != nil {
@@ -46,6 +47,7 @@ func (a Authenticator) IsSignedIn(token string) bool {
 	return true
 }
 
+// GetUser decodes authentication token to user data
 func (a Authenticator) GetUser(token string) (entity.User, error) {
 	payload, err := a.getPayload(token)
 	if err != nil {
@@ -64,6 +66,7 @@ func (a Authenticator) GetUser(token string) (entity.User, error) {
 	}, nil
 }
 
+// GenerateToken encodes part of user data into authentication token
 func (a Authenticator) GenerateToken(user entity.User) (string, error) {
 	issuedAt := a.timer.Now()
 	payload := newPayload(user.Email, issuedAt)
@@ -71,6 +74,7 @@ func (a Authenticator) GenerateToken(user entity.User) (string, error) {
 	return a.tokenizer.Encode(tokenPayload)
 }
 
+// NewAuthenticator initializes authenticator with custom token valid duration
 func NewAuthenticator(
 	tokenizer fw.CryptoTokenizer,
 	timer fw.Timer,

--- a/backend/app/usecase/auth/authenticator_test.go
+++ b/backend/app/usecase/auth/authenticator_test.go
@@ -117,7 +117,7 @@ func TestAuthenticator_GetUser(t *testing.T) {
 		currentTime        time.Time
 		tokenPayload       fw.TokenPayload
 		hasErr             bool
-		expUser           entity.User
+		expUser            entity.User
 	}{
 		{
 			name:               "Token payload empty",
@@ -126,7 +126,7 @@ func TestAuthenticator_GetUser(t *testing.T) {
 			currentTime:        now.Add(30 * time.Minute),
 			tokenPayload:       map[string]interface{}{},
 			hasErr:             true,
-			expUser:           entity.User{},
+			expUser:            entity.User{},
 		},
 		{
 			name:               "Token payload without email",
@@ -136,8 +136,8 @@ func TestAuthenticator_GetUser(t *testing.T) {
 			tokenPayload: map[string]interface{}{
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
-			hasErr:   true,
-			expUser:           entity.User{},
+			hasErr:  true,
+			expUser: entity.User{},
 		},
 		{
 			name:               "Token payload without issue_at",
@@ -147,8 +147,8 @@ func TestAuthenticator_GetUser(t *testing.T) {
 			tokenPayload: map[string]interface{}{
 				"email": "test@s.time4hacks.com",
 			},
-			hasErr:   true,
-			expUser:           entity.User{},
+			hasErr:  true,
+			expUser: entity.User{},
 		},
 		{
 			name:               "Token expired",
@@ -159,8 +159,8 @@ func TestAuthenticator_GetUser(t *testing.T) {
 				"email":     "test@s.time4hacks.com",
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
-			hasErr:   true,
-			expUser:           entity.User{},
+			hasErr:  true,
+			expUser: entity.User{},
 		},
 		{
 			name:               "Valid token with empty email",
@@ -171,8 +171,8 @@ func TestAuthenticator_GetUser(t *testing.T) {
 				"email":     "",
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
-			hasErr:   true,
-			expUser:           entity.User{},
+			hasErr:  true,
+			expUser: entity.User{},
 		},
 		{
 			name:               "Token valid with correct email",
@@ -183,9 +183,9 @@ func TestAuthenticator_GetUser(t *testing.T) {
 				"email":     "test@s.time4hacks.com",
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
-			hasErr:   false,
+			hasErr: false,
 			expUser: entity.User{
-				Email:"test@s.time4hacks.com",
+				Email: "test@s.time4hacks.com",
 			},
 		},
 	}

--- a/backend/app/usecase/auth/authenticator_test.go
+++ b/backend/app/usecase/auth/authenticator_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"short/app/entity"
 	"testing"
 	"time"
 
@@ -14,14 +15,16 @@ func TestAuthenticator_GenerateToken(t *testing.T) {
 	timer := mdtest.NewTimerFake(expIssuedAt)
 	authenticator := NewAuthenticator(tokenizer, timer, 2*time.Millisecond)
 
-	expEmail := "test@s.time4hacks.com"
-	token, err := authenticator.GenerateToken(expEmail)
+	expUser := entity.User{
+		Email: "test@s.time4hacks.com",
+	}
+	token, err := authenticator.GenerateToken(expUser)
 	mdtest.Equal(t, nil, err)
 
 	tokenPayload, err := tokenizer.Decode(token)
 	mdtest.Equal(t, nil, err)
 
-	mdtest.Equal(t, expEmail, tokenPayload["email"])
+	mdtest.Equal(t, expUser.Email, tokenPayload["email"])
 
 	expIssuedAtStr := expIssuedAt.Format(time.RFC3339Nano)
 	mdtest.Equal(t, expIssuedAtStr, tokenPayload["issued_at"])
@@ -104,7 +107,7 @@ func TestAuthenticator_IsSignedIn(t *testing.T) {
 	}
 }
 
-func TestAuthenticator_GetUserEmail(t *testing.T) {
+func TestAuthenticator_GetUser(t *testing.T) {
 	now := time.Now()
 
 	testCases := []struct {
@@ -114,7 +117,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 		currentTime        time.Time
 		tokenPayload       fw.TokenPayload
 		hasErr             bool
-		expEmail           string
+		expUser           entity.User
 	}{
 		{
 			name:               "Token payload empty",
@@ -123,7 +126,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 			currentTime:        now.Add(30 * time.Minute),
 			tokenPayload:       map[string]interface{}{},
 			hasErr:             true,
-			expEmail:           "",
+			expUser:           entity.User{},
 		},
 		{
 			name:               "Token payload without email",
@@ -134,7 +137,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
 			hasErr:   true,
-			expEmail: "",
+			expUser:           entity.User{},
 		},
 		{
 			name:               "Token payload without issue_at",
@@ -145,7 +148,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 				"email": "test@s.time4hacks.com",
 			},
 			hasErr:   true,
-			expEmail: "",
+			expUser:           entity.User{},
 		},
 		{
 			name:               "Token expired",
@@ -157,7 +160,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
 			hasErr:   true,
-			expEmail: "",
+			expUser:           entity.User{},
 		},
 		{
 			name:               "Valid token with empty email",
@@ -169,7 +172,7 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
 			hasErr:   true,
-			expEmail: "",
+			expUser:           entity.User{},
 		},
 		{
 			name:               "Token valid with correct email",
@@ -181,7 +184,9 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 				"issued_at": now.Format(time.RFC3339Nano),
 			},
 			hasErr:   false,
-			expEmail: "test@s.time4hacks.com",
+			expUser: entity.User{
+				Email:"test@s.time4hacks.com",
+			},
 		},
 	}
 
@@ -193,12 +198,12 @@ func TestAuthenticator_GetUserEmail(t *testing.T) {
 
 			token, err := tokenizer.Encode(testCase.tokenPayload)
 			mdtest.Equal(t, nil, err)
-			gotEmail, err := authenticator.GetUserEmail(token)
+			gotUser, err := authenticator.GetUser(token)
 			if testCase.hasErr {
 				mdtest.NotEqual(t, nil, err)
 				return
 			}
-			mdtest.Equal(t, testCase.expEmail, gotEmail)
+			mdtest.Equal(t, testCase.expUser, gotUser)
 		})
 	}
 }

--- a/backend/app/usecase/signin/oauth.go
+++ b/backend/app/usecase/signin/oauth.go
@@ -2,6 +2,7 @@ package signin
 
 import (
 	"errors"
+	"short/app/entity"
 	"short/app/usecase/auth"
 	"short/app/usecase/service"
 )
@@ -34,7 +35,10 @@ func (o OAuth) SignIn(authorizationCode string) (string, error) {
 		return "", err
 	}
 
-	authToken, err := o.authenticator.GenerateToken(email)
+	user := entity.User{
+		Email:email,
+	}
+	authToken, err := o.authenticator.GenerateToken(user)
 	if err != nil {
 		return "", err
 	}

--- a/backend/app/usecase/signin/oauth.go
+++ b/backend/app/usecase/signin/oauth.go
@@ -36,7 +36,7 @@ func (o OAuth) SignIn(authorizationCode string) (string, error) {
 	}
 
 	user := entity.User{
-		Email:email,
+		Email: email,
 	}
 	authToken, err := o.authenticator.GenerateToken(user)
 	if err != nil {

--- a/backend/dep/wire_gen.go
+++ b/backend/dep/wire_gen.go
@@ -7,6 +7,16 @@ package dep
 
 import (
 	"database/sql"
+	"short/app/adapter/db"
+	"short/app/adapter/facebook"
+	"short/app/adapter/github"
+	"short/app/adapter/graphql"
+	"short/app/usecase/account"
+	"short/app/usecase/requester"
+	"short/app/usecase/url"
+	"short/dep/provider"
+	"time"
+
 	"github.com/byliuyang/app/fw"
 	"github.com/byliuyang/app/modern/mdcli"
 	"github.com/byliuyang/app/modern/mddb"
@@ -18,15 +28,6 @@ import (
 	"github.com/byliuyang/app/modern/mdtimer"
 	"github.com/byliuyang/app/modern/mdtracer"
 	"github.com/google/wire"
-	"short/app/adapter/db"
-	"short/app/adapter/facebook"
-	"short/app/adapter/github"
-	"short/app/adapter/graphql"
-	"short/app/usecase/account"
-	"short/app/usecase/requester"
-	"short/app/usecase/url"
-	"short/dep/provider"
-	"time"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Authenticator is currently accepting and producing user email as unique identifier. However, some oauth providers do not provide user's email to Short backend, especially when users mark their emails as private. All the providers are offering user ID instead.

## New Behavior
### Description
Authenticator now accepts user struct as the inputs and outputs, leaving flexibility of migrating from email to user ID.
