### PR TITLE
Add change URL alias migration

### DIFF
--- a/backend/app/adapter/migration/9_change_url_alias_type.sql
+++ b/backend/app/adapter/migration/9_change_url_alias_type.sql
@@ -1,0 +1,2 @@
+-- +migrate Up
+ALTER TABLE url ALTER COLUMN alias TYPE CHARACTER VARYING(50);


### PR DESCRIPTION
Addresses #316.

- Assuming DB migration does not happen live and only at startup, we should not need to lock the table to perform this query
- There is already a frontend check to see whether alias goes 50 or over, so there's no need to handle cases where there's an alias 50 or over in the table (we would want the migration to fail in this case so we can assess why something like this would make it through)