### PR TITLE
Fix error collecting err codes

### DIFF
--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -3,7 +3,9 @@ import { IErr } from '../entity/Err';
 export enum ErrUrl {
   AliasAlreadyExist = 'aliasAlreadyExist',
   UserNotHuman = 'requesterNotHuman',
-  Unauthorized = 'invalidAuthToken'
+  Unauthorized = 'invalidAuthToken',
+  NetworkError = 'networkError',
+  Unknown = 'unknownError',
 }
 
 const unknownErr = {
@@ -33,6 +35,15 @@ const userNotHumanErr = {
                 `
 };
 
+const networkErr = {
+  name: 'Network error',
+  description: `
+              Could not get a response from the server. Please ensure you are
+              connected to the Internet and try again. If the problem persists,
+              please email byliuyang11@gmail.com.
+              `
+};
+
 export class ErrorService {
   getErr(errCode: ErrUrl): IErr {
     switch (errCode) {
@@ -40,6 +51,9 @@ export class ErrorService {
         return aliasNotAvailableErr;
       case ErrUrl.UserNotHuman:
         return userNotHumanErr;
+      case ErrUrl.NetworkError:
+        return networkErr;
+      case ErrUrl.Unknown:
       default:
         return unknownErr;
     }

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -40,7 +40,7 @@ const networkErr = {
   description: `
               Could not get a response from the server. Please ensure you are
               connected to the Internet and try again. If the problem persists,
-              please email byliuyang11@gmail.com.
+              please email byliuyang11@gmail.com with screenshots or logs.
               `
 };
 

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -38,9 +38,8 @@ const userNotHumanErr = {
 const networkErr = {
   name: 'Network error',
   description: `
-              Could not get a response from the server. Please ensure you are
-              connected to the Internet and try again. If the problem persists,
-              please email byliuyang11@gmail.com with screenshots or logs.
+              Unable to reach the server. Please double check your Internet connection and try again.
+              If this happens consistently, please email byliuyang11@gmail.com screenshots and the necessary steps to reproduce the error.
               `
 };
 

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -39,7 +39,7 @@ const networkErr = {
   name: 'Network error',
   description: `
               Unable to reach the server. Please double check your Internet connection and try again.
-              If this happens consistently, please email byliuyang11@gmail.com screenshots and the necessary steps to reproduce the error.
+              If this happens consistently, please email byliuyang11@gmail.com with screenshots and the necessary steps to reproduce the error.
               `
 };
 

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -1,6 +1,6 @@
 import { IErr } from '../entity/Err';
 
-export enum ErrUrl {
+export enum Err {
   AliasAlreadyExist = 'aliasAlreadyExist',
   UserNotHuman = 'requesterNotHuman',
   Unauthorized = 'invalidAuthToken',
@@ -45,15 +45,15 @@ const networkErr = {
 };
 
 export class ErrorService {
-  getErr(errCode: ErrUrl): IErr {
+  getErr(errCode: Err): IErr {
     switch (errCode) {
-      case ErrUrl.AliasAlreadyExist:
+      case Err.AliasAlreadyExist:
         return aliasNotAvailableErr;
-      case ErrUrl.UserNotHuman:
+      case Err.UserNotHuman:
         return userNotHumanErr;
-      case ErrUrl.NetworkError:
+      case Err.NetworkError:
         return networkErr;
-      case ErrUrl.Unknown:
+      case Err.Unknown:
       default:
         return unknownErr;
     }

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -150,10 +150,12 @@ export class UrlService {
         })
         .catch(({ graphQLErrors, networkError, message }) => {
           if (networkError) {
-            return reject([Err.NetworkError]);
+            reject([Err.NetworkError]);
+            return;
           }
           if (!graphQLErrors || graphQLErrors.length === 0) { 
-            return reject([Err.Unknown]);
+           reject([Err.Unknown]);
+           return;
           }
           const errCodes = graphQLErrors.map(
             (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : Err.Unknown

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -151,8 +151,8 @@ export class UrlService {
         .catch(({ graphQLErrors, networkError, message }) => {
           console.log(graphQLErrors);
           const errCodes = graphQLErrors.map(
-            (graphQLError: GraphQlError) => graphQLError.extensions.code
-          );
+            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : null
+          ).filter((errCode: string) => errCode !== null);
           reject(errCodes);
         });
     });

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -10,7 +10,7 @@ import { AuthService } from './Auth.service';
 import { CaptchaService, CREATE_SHORT_LINK } from './Captcha.service';
 import { validateLongLinkFormat } from '../validators/LongLink.validator';
 import { validateCustomAliasFormat } from '../validators/CustomAlias.validator';
-import { ErrorService, ErrUrl } from './Error.service';
+import { ErrorService, Err } from './Error.service';
 import { IErr } from '../entity/Err';
 
 interface IAuthMutation {
@@ -80,7 +80,7 @@ export class UrlService {
         return;
       } catch (errCodes) {
         const errCode = errCodes[0];
-        if (errCode === ErrUrl.Unauthorized) {
+        if (errCode === Err.Unauthorized) {
           reject({
             authorizationErr: 'Unauthorized to create short link'
           });
@@ -135,7 +135,7 @@ export class UrlService {
     );
     let alias = link.alias === '' ? null : link.alias!;
     let variables = this.gqlCreateURLVariable(captchaResponse, link, alias);
-    return new Promise<Url>((resolve, reject: (errCodes: ErrUrl[]) => any) => {
+    return new Promise<Url>((resolve, reject: (errCodes: Err[]) => any) => {
       this.gqlClient
         .mutate({
           variables: variables,
@@ -149,14 +149,14 @@ export class UrlService {
           resolve(res.data.authMutation.createURL);
         })
         .catch(({ graphQLErrors, networkError, message }) => {
-          if (!graphQLErrors || graphQLErrors.length === 0) {
-            if (networkError) {
-              return reject([ErrUrl.NetworkError]);
-            }
-            return reject([ErrUrl.Unknown]);
+          if (networkError) {
+            return reject([Err.NetworkError]);
+          }
+          if (!graphQLErrors || graphQLErrors.length === 0) { 
+            return reject([Err.Unknown]);
           }
           const errCodes = graphQLErrors.map(
-            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : ErrUrl.Unknown
+            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : Err.Unknown
           );
           reject(errCodes);
         });

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -154,11 +154,11 @@ export class UrlService {
             return;
           }
           if (!graphQLErrors || graphQLErrors.length === 0) { 
-           reject([Err.Unknown]);
-           return;
+            reject([Err.Unknown]);
+            return;
           }
           const errCodes = graphQLErrors.map(
-            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : Err.Unknown
+            (graphQLError: GraphQlError) => graphQLError.extensions ? graphQLError.extensions.code : Err.Unknown
           );
           reject(errCodes);
         });

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -149,10 +149,15 @@ export class UrlService {
           resolve(res.data.authMutation.createURL);
         })
         .catch(({ graphQLErrors, networkError, message }) => {
-          console.log(graphQLErrors);
+          if (!graphQLErrors || graphQLErrors.length === 0) {
+            if (networkError) {
+              return reject([ErrUrl.NetworkError]);
+            }
+            return reject([ErrUrl.Unknown]);
+          }
           const errCodes = graphQLErrors.map(
-            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : null
-          ).filter((errCode: string) => errCode !== null);
+            (graphQLError: GraphQlError) => (graphQLError.extensions) ? graphQLError.extensions.code : ErrUrl.Unknown
+          );
           reject(errCodes);
         });
     });


### PR DESCRIPTION
## Current Behavior
### Description
When collecting error codes in Url service error handler, it assumes that a `GraphQlError` object will always contain an `extensions` property and causes frontend to crash when `extensions` is missing.
![image](https://user-images.githubusercontent.com/3537801/69160547-a3f3dd00-0a9e-11ea-8f53-6a3db15db169.png)
See https://github.com/graphql/graphql-js/blob/v14.5.8/src/error/GraphQLError.js#L83

### Screenshots
## New Behavior
### Description
Now just unknown error will appear.
### Screenshots
<img width="647" alt="image" src="https://user-images.githubusercontent.com/3276350/69124802-8446bf80-0a72-11ea-9c7b-27c84227d492.png">
