### PR TITLE
Fix twitter card meta tags

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -39,8 +39,12 @@
     <meta property="og:type" content="website"/>
 
     <!-- Twitter -->
-    <meta name="twitter:card"
-          content="https://short-d.com/promo/large-tile.png">
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@byliuyang11"/>
+    <meta name="twitter:title" content="Short: Free link shortening"/>
+    <meta name="twitter:description"
+          content="SShort enables people to type less for their favorite web sites"/>
+    <meta name="twitter:image" content="https://short-d.com/promo/large-tile.png"/>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Twitter card preview fail to render

### Screenshots
<img width="632" alt="Screen Shot 2019-11-24 at 9 16 44 PM" src="https://user-images.githubusercontent.com/3537801/69514322-be471400-0eff-11ea-98c5-fa4d2fef3397.png">

## New Behavior
### Description
Twitter card preview renders successfully.
