### PR TITLE
Switch Twitter card preview to large image

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -39,7 +39,7 @@
     <meta property="og:type" content="website"/>
 
     <!-- Twitter -->
-    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@byliuyang11"/>
     <meta name="twitter:title" content="Short: Free link shortening"/>
     <meta name="twitter:description"


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Twitter card contains small image
### Screenshots
<img width="590" alt="Screen Shot 2019-11-24 at 9 28 23 PM" src="https://user-images.githubusercontent.com/3537801/69514811-6e694c80-0f01-11ea-8cf8-3db9d9c4a9a7.png">

## New Behavior
### Description
Twitter card contains large image
