### PR TITLE
Fix preview message

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -30,7 +30,7 @@
     <link href="https://short-d.com" rel="canonical">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Short: Free link shortening"/>
+    <meta property="og:title" content="Short: Free link shortening service"/>
     <meta property="og:description"
           content="Short enables people to type less for their favorite web sites"/>
     <meta property="og:image"
@@ -41,9 +41,9 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:site" content="@byliuyang11"/>
-    <meta name="twitter:title" content="Short: Free link shortening"/>
+    <meta name="twitter:title" content="Short: Free link shortening service"/>
     <meta name="twitter:description"
-          content="SShort enables people to type less for their favorite web sites"/>
+          content="Short enables people to type less for their favorite web sites"/>
     <meta name="twitter:image" content="https://short-d.com/promo/twitter-card.png"/>
 </head>
 <body>


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The is an extra `S` in Twitter card's description
### Screenshots
<img width="555" alt="Screen Shot 2019-11-24 at 10 01 39 PM" src="https://user-images.githubusercontent.com/3537801/69516308-26005d80-0f06-11ea-8b72-42a0c481ac8f.png">
Social media preview titles are not complete sentences.

## New Behavior
### Description
The extra `S` is removed. 
Update social media preview titles.