### PR TITLE
Add account linker

### DIFF
--- a/backend/app/usecase/account/linker.go
+++ b/backend/app/usecase/account/linker.go
@@ -1,0 +1,85 @@
+package account
+
+import (
+	"short/app/entity"
+	"short/app/usecase/keygen"
+	"short/app/usecase/repository"
+)
+
+type Linker struct {
+	keyGen             keygen.KeyGenerator
+	userRepo           repository.User
+	accountMappingRepo repository.AccountMapping
+}
+
+func (l Linker) IsAccountLinked(ssoUser entity.SSOUser) (bool, error) {
+	return l.accountMappingRepo.IsSSOUserExist(ssoUser)
+}
+
+func (l Linker) LinkAccount(ssoUser entity.SSOUser) error {
+	isAccountLinked, err := l.IsAccountLinked(ssoUser)
+	if err != nil {
+		return err
+	}
+
+	if isAccountLinked {
+		return nil
+	}
+
+	user, err := l.ensureUserExist(ssoUser)
+	if err != nil {
+		return err
+	}
+	return l.accountMappingRepo.CreateMapping(ssoUser, user)
+}
+
+func (l Linker) ensureUserExist(ssoUser entity.SSOUser) (entity.User, error) {
+	isEmailExist, err := l.userRepo.IsEmailExist(ssoUser.Email)
+	if err != nil {
+		return entity.User{}, err
+	}
+	userID, err := l.generateUnassignedUserID()
+	if err != nil {
+		return entity.User{}, err
+	}
+
+	if isEmailExist {
+		err = l.assignUserID(ssoUser.Email, userID)
+		return entity.User{ID: userID}, err
+	}
+	return l.createUser(userID, ssoUser.Name, ssoUser.Email)
+}
+
+func (l Linker) generateUnassignedUserID() (string, error) {
+	newKey, err := l.keyGen.NewKey()
+	return string(newKey), err
+}
+
+func (l Linker) createUser(id string, name string, email string) (entity.User, error) {
+	user := entity.User{
+		ID:    id,
+		Name:  name,
+		Email: email,
+	}
+	err := l.userRepo.CreateUser(user)
+	if err != nil {
+		return entity.User{}, err
+	}
+	return user, nil
+}
+
+func (l Linker) assignUserID(userEmail string, userID string) error {
+	return l.userRepo.UpdateUserID(userEmail, userID)
+}
+
+func NewLinker(
+	keyGen keygen.KeyGenerator,
+	userRepo repository.User,
+	accountMappingRepo repository.AccountMapping,
+) Linker {
+	return Linker{
+		keyGen:             keyGen,
+		userRepo:           userRepo,
+		accountMappingRepo: accountMappingRepo,
+	}
+}

--- a/backend/app/usecase/account/linker.go
+++ b/backend/app/usecase/account/linker.go
@@ -6,17 +6,23 @@ import (
 	"short/app/usecase/repository"
 )
 
+// Linker provides account linking service.
 type Linker struct {
 	keyGen             keygen.KeyGenerator
 	userRepo           repository.User
 	accountMappingRepo repository.AccountMapping
 }
 
+// IsAccountLinked checks whether a given external account is linked to any
+// internal users already.
 func (l Linker) IsAccountLinked(ssoUser entity.SSOUser) (bool, error) {
 	return l.accountMappingRepo.IsSSOUserExist(ssoUser)
 }
 
-func (l Linker) LinkAccount(ssoUser entity.SSOUser) error {
+// EnsureAndLinkAccount creates an internal account when there is no internal
+// account sharing the same email as the given external account and link them
+// together afterwards.
+func (l Linker) EnsureAndLinkAccount(ssoUser entity.SSOUser) error {
 	isAccountLinked, err := l.IsAccountLinked(ssoUser)
 	if err != nil {
 		return err
@@ -72,6 +78,7 @@ func (l Linker) assignUserID(userEmail string, userID string) error {
 	return l.userRepo.UpdateUserID(userEmail, userID)
 }
 
+// NewLinker creates a new account linking service.
 func NewLinker(
 	keyGen keygen.KeyGenerator,
 	userRepo repository.User,

--- a/backend/app/usecase/account/linker.go
+++ b/backend/app/usecase/account/linker.go
@@ -19,10 +19,10 @@ func (l Linker) IsAccountLinked(ssoUser entity.SSOUser) (bool, error) {
 	return l.accountMappingRepo.IsSSOUserExist(ssoUser)
 }
 
-// EnsureAndLinkAccount creates an internal account when there is no internal
+// CreateAndLinkAccount creates an internal account when there is no internal
 // account sharing the same email as the given external account and link them
 // together afterwards.
-func (l Linker) EnsureAndLinkAccount(ssoUser entity.SSOUser) error {
+func (l Linker) CreateAndLinkAccount(ssoUser entity.SSOUser) error {
 	isAccountLinked, err := l.IsAccountLinked(ssoUser)
 	if err != nil {
 		return err

--- a/backend/app/usecase/account/linker_test.go
+++ b/backend/app/usecase/account/linker_test.go
@@ -158,7 +158,7 @@ func TestLinker_LinkAccount(t *testing.T) {
 			mdtest.Equal(t, nil, err)
 
 			linker := NewLinker(&keyGen, &fakeUserRepo, &accountMappingRepo)
-			err = linker.LinkAccount(testCase.ssoUser)
+			err = linker.CreateAndLinkAccount(testCase.ssoUser)
 			mdtest.Equal(t, nil, err)
 
 			gotIsRelationExist := accountMappingRepo.IsRelationExist(testCase.ssoUser, testCase.user)

--- a/backend/app/usecase/account/linker_test.go
+++ b/backend/app/usecase/account/linker_test.go
@@ -1,0 +1,171 @@
+package account
+
+import (
+	"short/app/entity"
+	"short/app/usecase/keygen"
+	"short/app/usecase/repository"
+	"testing"
+
+	"github.com/byliuyang/app/mdtest"
+)
+
+func TestLinker_IsAccountLinked(t *testing.T) {
+	testCases := []struct {
+		name             string
+		keys             []string
+		users            []entity.User
+		mappingUsers     []entity.User
+		mappingSSOUsers  []entity.SSOUser
+		ssoUser          entity.SSOUser
+		expectedIsLinked bool
+	}{
+		{
+			name:            "account not linked",
+			keys:            []string{},
+			mappingUsers:    []entity.User{},
+			mappingSSOUsers: []entity.SSOUser{},
+			ssoUser: entity.SSOUser{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+				Name:  "Alpha User",
+			},
+			expectedIsLinked: false,
+		},
+		{
+			name: "account already linked",
+			keys: []string{},
+			mappingUsers: []entity.User{
+				{
+					ID:    "beta",
+					Name:  "Beta",
+					Email: "beta@example.com",
+				},
+			},
+			mappingSSOUsers: []entity.SSOUser{
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+					Name:  "Alpha User",
+				},
+			},
+			ssoUser: entity.SSOUser{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+				Name:  "Alpha User",
+			},
+			expectedIsLinked: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			keyGen := keygen.NewFake(testCase.keys)
+			userRepo := repository.NewUserFake(testCase.users)
+			accountMappingRepo, err :=
+				repository.NewAccountMappingFake(
+					testCase.mappingSSOUsers,
+					testCase.mappingUsers,
+				)
+			mdtest.Equal(t, nil, err)
+
+			linker := NewLinker(&keyGen, &userRepo, &accountMappingRepo)
+			isLinked, err := linker.IsAccountLinked(testCase.ssoUser)
+			mdtest.Equal(t, nil, err)
+			mdtest.Equal(t, testCase.expectedIsLinked, isLinked)
+		})
+	}
+}
+
+func TestLinker_LinkAccount(t *testing.T) {
+	testCases := []struct {
+		name            string
+		key             string
+		mappingUsers    []entity.User
+		mappingSSOUsers []entity.SSOUser
+		users           []entity.User
+		ssoUser         entity.SSOUser
+		user            entity.User
+	}{
+		{
+			name: "account already linked",
+			mappingUsers: []entity.User{
+				{
+					ID: "alpha",
+				},
+			},
+			mappingSSOUsers: []entity.SSOUser{
+				{
+					ID: "gama",
+				},
+			},
+			users: []entity.User{
+				{
+					ID: "alpha",
+				},
+			},
+			ssoUser: entity.SSOUser{
+				ID: "gama",
+			},
+			user: entity.User{
+				ID: "alpha",
+			},
+		},
+		{
+			name:            "account exists not linked",
+			key:             "alpha",
+			mappingUsers:    []entity.User{},
+			mappingSSOUsers: []entity.SSOUser{},
+			users: []entity.User{
+				{
+					Email: "alpha@example.com",
+				},
+			},
+			ssoUser: entity.SSOUser{
+				ID:    "gama",
+				Email: "alpha@example.com",
+			},
+			user: entity.User{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+			},
+		},
+		{
+			name:            "create new account",
+			key:             "alpha",
+			mappingUsers:    []entity.User{},
+			mappingSSOUsers: []entity.SSOUser{},
+			users:           []entity.User{},
+			ssoUser: entity.SSOUser{
+				ID:    "gama",
+				Email: "alpha@example.com",
+			},
+			user: entity.User{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			keyGen := keygen.NewFake([]string{testCase.key})
+			fakeUserRepo := repository.NewUserFake(testCase.users)
+			accountMappingRepo, err :=
+				repository.NewAccountMappingFake(
+					testCase.mappingSSOUsers,
+					testCase.mappingUsers,
+				)
+			mdtest.Equal(t, nil, err)
+
+			linker := NewLinker(&keyGen, &fakeUserRepo, &accountMappingRepo)
+			err = linker.LinkAccount(testCase.ssoUser)
+			mdtest.Equal(t, nil, err)
+
+			gotIsRelationExist := accountMappingRepo.IsRelationExist(testCase.ssoUser, testCase.user)
+			mdtest.Equal(t, true, gotIsRelationExist)
+
+			gotIsIDExist := fakeUserRepo.IsUserIDExist(testCase.user.ID)
+			mdtest.Equal(t, true, gotIsIDExist)
+		})
+	}
+}


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
External account is mapped to Short's internal account through email. However, some identity provider only reveals user's public email, resulting in sign in failure.

## New Behavior
### Description
Add account linker to map external account to Short's internal account through user IDs.
