### PR TITLE
Add Google OAuth IdentityProvider

### DIFF
--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -30,7 +30,7 @@ var _ service.IdentityProvider = (*IdentityProvider)(nil)
 type IdentityProvider struct {
 	clientID     string
 	clientSecret string
-	http         fw.HTTPRequest
+	httpRequest         fw.HTTPRequest
 	redirectURI  string
 }
 

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"short/app/usecase/service"
@@ -35,12 +34,8 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 	includeGrantedScopes := "true"
 	responseType := "code"
 	clientID := g.clientID
-	redirectURI, err := url.QueryUnescape(g.redirectURI)
-	if err != nil {
-		return ""
-	}
-	fmt.Println(redirectURI)
-	fmt.Println(g.redirectURI)
+	redirectURI := g.redirectURI
+
 	u, err := url.Parse(authorizationAPI)
 	if err != nil {
 		return ""
@@ -63,10 +58,7 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	grantType := "authorization_code"
 	clientID := g.clientID
 	clientSecret := g.clientSecret
-	redirectURI, err := url.QueryUnescape(g.redirectURI)
-	if err != nil {
-		return "", err
-	}
+	redirectURI := g.redirectURI
 
 	u, err := url.Parse(accessTokenAPI)
 	if err != nil {
@@ -107,6 +99,6 @@ func NewIdentityProvider(http fw.HTTPRequest, clientID string, clientSecret stri
 		clientID:     clientID,
 		clientSecret: clientSecret,
 		httpRequest:  http,
-		redirectURI:  url.QueryEscape(redirectURI),
+		redirectURI:  redirectURI,
 	}
 }

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -10,13 +10,13 @@ import (
 )
 
 const (
-	authorizationAPI 	 = "https://accounts.google.com/o/oauth2/v2/auth?"
-	accessTokenAPI   	 = "https://www.googleapis.com/oauth2/v3/token"
-	grantType        	 = "authorization_code"
-	scope 			 	 = "https://www.googleapis.com/auth/userinfo.email"
-	accessType 		 	 = "offline"
+	authorizationAPI     = "https://accounts.google.com/o/oauth2/v2/auth?"
+	accessTokenAPI       = "https://www.googleapis.com/oauth2/v3/token"
+	grantType            = "authorization_code"
+	scope                = "https://www.googleapis.com/auth/userinfo.email"
+	accessType           = "offline"
 	includeGrantedScopes = "true"
-	responseType	 	 = "code"
+	responseType         = "code"
 )
 
 type accessTokenResponse struct {

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	authorizationAPI     = "https://accounts.google.com/o/oauth2/v2/auth?"
+	authorizationAPI     = "https://accounts.google.com/o/oauth2/v2/auth"
 	accessTokenAPI       = "https://www.googleapis.com/oauth2/v3/token"
 	grantType            = "authorization_code"
 	scope                = "https://www.googleapis.com/auth/userinfo.email"

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -1,0 +1,75 @@
+package google
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"short/app/usecase/service"
+
+	"github.com/byliuyang/app/fw"
+)
+
+const (
+	authorizationAPI 	 = "https://accounts.google.com/o/oauth2/v2/auth?"
+	accessTokenAPI   	 = "https://www.googleapis.com/oauth2/v3/token"
+	grantType        	 = "authorization_code"
+	scope 			 	 = "https://www.googleapis.com/auth/userinfo.email"
+	accessType 		 	 = "offline"
+	includeGrantedScopes = "true"
+	responseType	 	 = "code"
+)
+
+type accessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+var _ service.IdentityProvider = (*IdentityProvider)(nil)
+
+// IdentityProvider represents Google OAuth service.
+type IdentityProvider struct {
+	clientID     string
+	clientSecret string
+	http         fw.HTTPRequest
+	redirectURI  string
+}
+
+// GetAuthorizationURL retrieves the URL of Google sign in page.
+func (g IdentityProvider) GetAuthorizationURL() string {
+	clientID := g.clientID
+	redirectURI := g.redirectURI
+	return fmt.Sprintf("%s&client_id=%s&redirect_uri=%s&scope=%s&access_type=%s&include_granted_scopes=%s&response_type=%s",
+		authorizationAPI, clientID, redirectURI, scope, accessType, includeGrantedScopes, responseType)
+}
+
+// RequestAccessToken retrieves access token of user's Google account using
+// authorization code.
+func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, error) {
+	clientID := g.clientID
+	clientSecret := g.clientSecret
+	redirectURI := g.redirectURI
+
+	u := fmt.Sprintf("%s?code=%s&client_id=%s&client_secret=%s&redirect_uri=%s&grant_type=%s",
+		accessTokenAPI, authorizationCode, clientID, clientSecret, redirectURI, grantType)
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+
+	apiRes := accessTokenResponse{}
+	err := g.http.JSON(http.MethodPost, u, headers, "", &apiRes)
+	if err != nil {
+		return "", err
+	}
+
+	return apiRes.AccessToken, nil
+}
+
+// NewIdentityProvider initializes Google OAuth service.
+func NewIdentityProvider(http fw.HTTPRequest, clientID string, clientSecret string, redirectURI string) IdentityProvider {
+	return IdentityProvider{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		http:         http,
+		redirectURI:  url.QueryEscape(redirectURI),
+	}
+}

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -13,11 +13,6 @@ const (
 	accessTokenAPI   = "https://www.googleapis.com/oauth2/v4/token"
 )
 
-type accessTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-}
-
 var _ service.IdentityProvider = (*IdentityProvider)(nil)
 
 // IdentityProvider represents Google OAuth service.
@@ -30,9 +25,6 @@ type IdentityProvider struct {
 
 // GetAuthorizationURL retrieves the URL of Google sign in page.
 func (g IdentityProvider) GetAuthorizationURL() string {
-	scope := "profile"
-	includeGrantedScopes := "true"
-	responseType := "code"
 	clientID := g.clientID
 	redirectURI := g.redirectURI
 
@@ -41,13 +33,13 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 		return ""
 	}
 
-	q := u.Query()
-	q.Set("client_id", clientID)
-	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", scope)
-	q.Set("include_granted_scopes", includeGrantedScopes)
-	q.Set("response_type", responseType)
-	u.RawQuery = q.Encode()
+	query := u.Query()
+	query.Set("client_id", clientID)
+	query.Set("redirect_uri", redirectURI)
+	query.Set("scope", "profile")
+	query.Set("include_granted_scopes", "true")
+	query.Set("response_type", "code")
+	u.RawQuery = query.Encode()
 
 	return u.String()
 }
@@ -91,6 +83,11 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	}
 
 	return apiRes.AccessToken, nil
+}
+
+type accessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
 }
 
 // NewIdentityProvider initializes Google OAuth service.

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	authorizationAPI     = "https://accounts.google.com/o/oauth2/v2/auth"
-	accessTokenAPI       = "https://www.googleapis.com/oauth2/v3/token"
+	authorizationAPI     = "accounts.google.com"
+	accessTokenAPI       = "www.googleapis.com"
 	grantType            = "authorization_code"
 	scope                = "https://www.googleapis.com/auth/userinfo.email"
 	accessType           = "offline"
@@ -41,6 +41,7 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 	u := &url.URL{
 		Scheme: "https",
 		Host:   authorizationAPI,
+		Path:   "o/oauth2/v2/auth",
 		RawQuery: fmt.Sprintf("&client_id=%s&redirect_uri=%s&scope=%s&access_type=%s&include_granted_scopes=%s&response_type=%s",
 			clientID, redirectURI, scope, accessType, includeGrantedScopes, responseType),
 	}
@@ -57,6 +58,7 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	u := &url.URL{
 		Scheme: "https",
 		Host:   accessTokenAPI,
+		Path:   "oauth2/v3/token",
 		RawQuery: fmt.Sprintf("code=%s&client_id=%s&client_secret=%s&redirect_uri=%s&grant_type=%s",
 			authorizationCode, clientID, clientSecret, redirectURI, grantType),
 	}

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -39,8 +39,8 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 	clientID := g.clientID
 	redirectURI := g.redirectURI
 	u := &url.URL{
-		Scheme:   "https",
-		Host:     authorizationAPI,
+		Scheme: "https",
+		Host:   authorizationAPI,
 		RawQuery: fmt.Sprintf("&client_id=%s&redirect_uri=%s&scope=%s&access_type=%s&include_granted_scopes=%s&response_type=%s",
 			clientID, redirectURI, scope, accessType, includeGrantedScopes, responseType),
 	}
@@ -55,8 +55,8 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	redirectURI := g.redirectURI
 
 	u := &url.URL{
-		Scheme:   "https",
-		Host:     accessTokenAPI,
+		Scheme: "https",
+		Host:   accessTokenAPI,
 		RawQuery: fmt.Sprintf("code=%s&client_id=%s&client_secret=%s&redirect_uri=%s&grant_type=%s",
 			authorizationCode, clientID, clientSecret, redirectURI, grantType),
 	}


### PR DESCRIPTION
## New Behavior
### Description
Add Google OAuth IdentifyProvider.

In order to support Google sign in, we are mapping user's Google account to user's  Short account through user's email. User email can be retrieved from Google API given OAuth token, which is provided by Google OAuth IdentityProvider.