### PR TITLE
Add Google OAuth API in route.go

### DIFF
--- a/backend/app/adapter/routing/route.go
+++ b/backend/app/adapter/routing/route.go
@@ -3,8 +3,8 @@ package routing
 import (
 	netURL "net/url"
 	"short/app/adapter/facebook"
-	"short/app/adapter/google"
 	"short/app/adapter/github"
+	"short/app/adapter/google"
 	"short/app/usecase/account"
 	"short/app/usecase/auth"
 	"short/app/usecase/sso"

--- a/backend/app/adapter/routing/route.go
+++ b/backend/app/adapter/routing/route.go
@@ -3,6 +3,7 @@ package routing
 import (
 	netURL "net/url"
 	"short/app/adapter/facebook"
+	"short/app/adapter/google"
 	"short/app/adapter/github"
 	"short/app/usecase/account"
 	"short/app/usecase/auth"
@@ -27,6 +28,7 @@ func NewShort(
 	urlRetriever url.Retriever,
 	githubAPI github.API,
 	facebookAPI facebook.API,
+	googleAPI google.API,
 	authenticator auth.Authenticator,
 	accountProvider account.Provider,
 ) []fw.Route {
@@ -39,6 +41,12 @@ func NewShort(
 	facebookSignIn := sso.NewSingleSignOn(
 		facebookAPI.IdentityProvider,
 		facebookAPI.Account,
+		accountProvider,
+		authenticator,
+	)
+	googleSignIn := sso.NewSingleSignOn(
+		googleAPI.IdentityProvider,
+		googleAPI.Account,
 		accountProvider,
 		authenticator,
 	)
@@ -88,6 +96,27 @@ func NewShort(
 				logger,
 				tracer,
 				facebookSignIn,
+				*frontendURL,
+			),
+		},
+		{
+			Method: "GET",
+			Path:   "/oauth/google/sign-in",
+			Handle: NewSSOSignIn(
+				logger,
+				tracer,
+				googleAPI.IdentityProvider,
+				authenticator,
+				webFrontendURL,
+			),
+		},
+		{
+			Method: "GET",
+			Path:   "/oauth/google/sign-in/callback",
+			Handle: NewSSOSignInCallback(
+				logger,
+				tracer,
+				googleSignIn,
 				*frontendURL,
 			),
 		},

--- a/backend/dep/provider/routes.go
+++ b/backend/dep/provider/routes.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"short/app/adapter/facebook"
 	"short/app/adapter/github"
+	"short/app/adapter/google"
 	"short/app/adapter/routing"
 	"short/app/usecase/account"
 	"short/app/usecase/auth"
@@ -23,6 +24,7 @@ func NewShortRoutes(
 	urlRetriever url.Retriever,
 	githubAPI github.API,
 	facebookAPI facebook.API,
+	googleAPI google.API,
 	authenticator auth.Authenticator,
 	accountProvider account.Provider,
 ) []fw.Route {
@@ -38,6 +40,7 @@ func NewShortRoutes(
 		urlRetriever,
 		githubAPI,
 		facebookAPI,
+		googleAPI,
 		authenticator,
 		accountProvider,
 	)


### PR DESCRIPTION
## New Behavior
Add Google OAuth API in route.go

In order to support Google sign in, we are mapping user's Google account to user's Short account through user's email. Route.go links the function with URL path to handle NewSSOSignIn and NewSSOSignInCallback.