### PR TITLE
Turn on Google sign in button

### DIFF
--- a/frontend/src/service/StaticConfigDecision.service.ts
+++ b/frontend/src/service/StaticConfigDecision.service.ts
@@ -5,7 +5,7 @@ export class StaticConfigDecisionService implements IFeatureDecisionService {
     return false;
   }
   includeGoogleSignButton(): boolean {
-    return false;
+    return true;
   }
   includeFacebookSignButton(): boolean {
     return true;


### PR DESCRIPTION
## New Behavior
Turn on Google sign in button.

In order to support Google sign in, we are mapping user's Google account to user's Short account through user's email. Turn on Google sign in button allows user to use Google OAuth API to sign in.